### PR TITLE
Replace pre-occupied fields for email and password with placeholders

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -18,7 +18,7 @@
                             {{ __('E-Mail Address') }}:
                         </label>
                         {{-- TODO: REMOVE VALUE --}}
-                        <input id="email" type="email" value="superadmin@wiki.app"
+                        <input id="email" type="email" placeholder="superadmin@wiki.app"
                             class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline{{ $errors->has('email') ? ' border-red-500' : '' }}"
                             name="email" value="{{ old('email') }}" required autofocus>
 
@@ -34,7 +34,7 @@
                             {{ __('Password') }}:
                         </label>
                         {{-- TODO: REMOVE VALUE --}}
-                        <input id="password" type="password" value="password"
+                        <input id="password" type="password" placeholder="******"
                             class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline{{ $errors->has('password') ? ' border-red-500' : '' }}"
                             name="password" required>
 


### PR DESCRIPTION
Currently, on the login page the e-mail and password field are pre-occupied with an e-mail address and the password "password". I think it might be better to replace those with a placeholder as proposed in this PR. 

<img width="469" alt="Schermafbeelding 2019-10-14 om 17 00 29" src="https://user-images.githubusercontent.com/24190396/66761376-30a9ea80-eea4-11e9-8107-4ef56c875ae0.png">