### PR TITLE
Fix error and add sections to favorites page

### DIFF
--- a/resources/views/favorites.blade.php
+++ b/resources/views/favorites.blade.php
@@ -14,13 +14,18 @@ Your Favorites
 
 <div>
     <ul>
-        @foreach ($favorites as $favorite)
-        <li class="py-2">
-            <a href="{{ $favorite[0]->getUrl() }}">{{ $favorite[0]->name }}</a>
-            <span class="px-2 text-gray-500 block sm:inline-flex">
-                {{ substr($favorite[0]->content, 0, 150) . '...' }}
-            </span>
-        </li>
+        @foreach ($favorites as $section => $favorites)
+        <h1>{{ $section }}</h1>
+            @forelse ($favorites as $favorite)
+            <li class="py-2">
+                <a href="{{ $favorite->getUrl() }}">{{ $favorite->name }}</a>
+                <span class="px-2 text-gray-500 block sm:inline-flex">
+                    {{ substr($favorite->content, 0, 150) . '...' }}
+                </span>
+            </li>
+            @empty
+                <li class="py-2">No favorites in this section (yet).</li>
+            @endforelse
         @endforeach
     </ul>
 </div>


### PR DESCRIPTION
As mentioned in issue #6, this PR fixed the '/favorites' endpoint and shows the favorited items in the respective section.

<img width="751" alt="Schermafbeelding 2019-10-14 om 17 29 06" src="https://user-images.githubusercontent.com/24190396/66763488-30135300-eea8-11e9-8e3c-3d6348837712.png">